### PR TITLE
[1.20.1] Make casts in LivingEntityRenderMixin safe

### DIFF
--- a/common/src/main/java/com/zigythebird/playeranimatorapi/mixin/LivingEntityRendererMixin.java
+++ b/common/src/main/java/com/zigythebird/playeranimatorapi/mixin/LivingEntityRendererMixin.java
@@ -2,17 +2,14 @@ package com.zigythebird.playeranimatorapi.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.zigythebird.playeranimatorapi.data.PlayerParts;
-import com.zigythebird.playeranimatorapi.misc.PlayerModelInterface;
 import com.zigythebird.playeranimatorapi.playeranims.CustomModifierLayer;
 import com.zigythebird.playeranimatorapi.playeranims.PlayerAnimations;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,9 +24,8 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity, M extend
 
     @Inject(method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", at = @At("TAIL"), cancellable = true)
     private void render(T entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
-        if (entity instanceof Player) {
-            CustomModifierLayer animationContainer = PlayerAnimations.getModifierLayer((AbstractClientPlayer) entity);
-            PlayerModel playerModel = ((PlayerModel) (this.model));
+        if (entity instanceof AbstractClientPlayer playerEntity && this.model instanceof PlayerModel<?> playerModel) {
+            CustomModifierLayer<?> animationContainer = PlayerAnimations.getModifierLayer(playerEntity);
 
             if (animationContainer != null && animationContainer.isActive()) {
                 PlayerParts parts = animationContainer.data.parts();


### PR DESCRIPTION
Fixes #15

Also simplified the if to a pattern matching one to remove the explicit cast.