### PR TITLE
[1.21] Make casts in LivingEntityRenderMixin safe

### DIFF
--- a/common/src/main/java/com/zigythebird/playeranimatorapi/mixin/LivingEntityRendererMixin.java
+++ b/common/src/main/java/com/zigythebird/playeranimatorapi/mixin/LivingEntityRendererMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,9 +24,8 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity, M extend
 
     @Inject(method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", at = @At("TAIL"), cancellable = true)
     private void render(T entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
-        if (entity instanceof Player) {
-            CustomModifierLayer animationContainer = PlayerAnimations.getModifierLayer((AbstractClientPlayer) entity);
-            PlayerModel playerModel = ((PlayerModel) (this.model));
+        if (entity instanceof AbstractClientPlayer playerEntity && this.model instanceof PlayerModel<?> playerModel) {
+            CustomModifierLayer<?> animationContainer = PlayerAnimations.getModifierLayer(playerEntity);
 
             if (animationContainer != null && animationContainer.isActive()) {
                 PlayerParts parts = animationContainer.data.parts();


### PR DESCRIPTION
Applies #16 to 1.21 branch.